### PR TITLE
Set up CI with Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,5 +24,5 @@ steps:
   inputs:
     azureSubscription: $(azureSubscription)
     appName: $(appName)
-    imageName: $(imagePrefix)/$(imageRepository):$(tag)
+    imageName: $(imageRepository):$(tag)
   displayName: 'Run a multi-line script'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@
 # https://aka.ms/yaml
 
 trigger:
-- main
+- azure-pipelines
 
 pool:
   vmImage: ubuntu-latest
@@ -24,5 +24,5 @@ steps:
   inputs:
     azureSubscription: $(azureSubscription)
     appName: $(appName)
-    imageName: $(imageRepository):$(tag)
+    imageName: $(containerRegistrySubdomain).azurecr.io/$(imageRepository):$(tag)
   displayName: 'Run a multi-line script'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,28 @@
+# Starter pipeline
+# Start with a minimal pipeline that you can customize to build and deploy your code.
+# Add steps that build, run tests, deploy, and more:
+# https://aka.ms/yaml
+
+trigger:
+- main
+
+pool:
+  vmImage: ubuntu-latest
+variables:
+  tag: $(Build.BuildId)
+
+steps:
+- task: Docker@2
+  inputs:
+    containerRegistry: $(containerRegistry)
+    repository: $(imageRepository)
+    command: 'buildAndPush'
+    Dockerfile: '**/Dockerfile'
+    tags: $(tag)
+
+- task: AzureFunctionAppContainer@1
+  inputs:
+    azureSubscription: $(azureSubscription)
+    appName: $(appName)
+    imageName: $(containerRegistry)/$(imageRepository):$(tag)
+  displayName: 'Run a multi-line script'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,5 +24,5 @@ steps:
   inputs:
     azureSubscription: $(azureSubscription)
     appName: $(appName)
-    imageName: $(containerRegistry)/$(imageRepository):$(tag)
+    imageName: $(imagePrefix)/$(imageRepository):$(tag)
   displayName: 'Run a multi-line script'


### PR DESCRIPTION
Because Azure Function image deployment webhooks are not supported by the Terraform Azure Provider [yet](https://github.com/terraform-providers/terraform-provider-azurerm/issues/9593), we need to use Azure DevOps Pipelines to:
1. Build and push an image to the Azure Container Registry
1. Deploy the the build's image to the Azure Function